### PR TITLE
Record::is_owner: Replace Affine comparison with x coord comparison

### DIFF
--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -29,13 +29,9 @@ impl<N: Network> Record<N, Ciphertext<N>> {
                 // Compute the 0th randomizer.
                 let randomizer = N::hash_many_psd8(&[N::encryption_domain(), record_view_key], 1);
                 // Decrypt the owner.
-                match Address::from_field(&(ciphertext[0] - randomizer[0])) {
-                    Ok(owner) => &owner == address,
-                    Err(error) => {
-                        eprintln!("Failed to decrypt the record owner: {error}");
-                        false
-                    }
-                }
+                let owner_x = ciphertext[0] - randomizer[0];
+                // Compare the x coordinates of computed and supplied affines.
+                owner_x == address.to_x_coordinate()
             }
         }
     }


### PR DESCRIPTION
`Address` is a wrapper for a `Projective` which is a valid point on `Environment`'s curve. Previously we computed the 'x' coordinate from the `Record`'s ciphertext and the `ViewKey` and tried to create a valid `Address` from it. This basically computes the point on the curve which all parameters are fixed (only 'x' and 'y' are varying), so knowing 'x' we'll always compute the same 'y' (well, not really since those are higher than 1 degrees polynomials so they can have many solutions, however computing address would check all possibilities and take the correct one). However since we are comparing it to the provided (already correct) `Address` so we don't need to care about all of that as we can just compare their x coordinates instead as if there exists an address for given x, then it's been already proven that it's possible to compute the point from this x.