### PR TITLE
Record::is_owner: Replace Affine comparison with x coord comparison

### DIFF
--- a/console/program/src/data/record/is_owner.rs
+++ b/console/program/src/data/record/is_owner.rs
@@ -29,13 +29,9 @@ impl<N: Network> Record<N, Ciphertext<N>> {
                 // Compute the 0th randomizer.
                 let randomizer = N::hash_many_psd8(&[N::encryption_domain(), record_view_key], 1);
                 // Decrypt the owner.
-                match Address::from_field(&(ciphertext[0] - randomizer[0])) {
-                    Ok(owner) => &owner == address,
-                    Err(error) => {
-                        eprintln!("Failed to decrypt the record owner: {error}");
-                        false
-                    }
-                }
+                let owner_x = ciphertext[0] - randomizer[0];
+                // Compare the x coordinates of computed and supplied affines.
+                owner_x == address.to_x_coordinate()
             }
         }
     }


### PR DESCRIPTION
Address is a wrapper for an Affine which is a valid point on Environment's curve. Previously we computed the 'x' coordinate from the Record's ciphertext and the ViewKey and tried to create a valid Address from it. This basically tries to compute the point on the curve which all parameters are fixed (only 'x' and 'y' are varying). That means that for each x from the domain there exist at least one solution and computing the Address can be understood as checking if this x belongs to domain of our Environments curve.
However since we are about to comparie it to the provided (already correct) Address we don't need to care about all of that as we can just compare the computed x coordinate to the provided one. If there exists an address for given x, then it's been already proven that it's possible to compute the point from this x so it must belong to the domain.

For 2000 transactions
ViewKey 1 is_owner - took 1470ms
ViewKey 2 is_owner - took 1460ms
ViewKey 3 is_owner - took 1426ms
ViewKey 4 is_owner - took 1459ms

For 2000 transactions
ViewKey 1 is_owner - took 1016ms
ViewKey 2 is_owner - took 983ms
ViewKey 3 is_owner - took 979ms
ViewKey 4 is_owner - took 995ms

`-31.7%`