### PR TITLE
Optimize console poseidon sponge apply_s_box

### DIFF
--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -111,14 +111,15 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
     #[inline]
     fn apply_s_box(&mut self, is_full_round: bool) {
         // Full rounds apply the S Box (x^alpha) to every element of state
+        let alpha = Field::from_u64(self.parameters.alpha);
         if is_full_round {
             for elem in self.state.iter_mut() {
-                *elem = elem.pow(Field::from_u64(self.parameters.alpha));
+                *elem = elem.pow(alpha);
             }
         }
         // Partial rounds apply the S Box (x^alpha) to just the first element of state
         else {
-            self.state[0] = self.state[0].pow(Field::from_u64(self.parameters.alpha));
+            self.state[0] = self.state[0].pow(alpha);
         }
     }
 


### PR DESCRIPTION
For 2000 transactions
ViewKey 1 is_owner - took 1016ms
ViewKey 2 is_owner - took 983ms
ViewKey 3 is_owner - took 979ms
ViewKey 4 is_owner - took 995ms

For 2000 transactions
ViewKey 1 is_owner - took 981ms
ViewKey 2 is_owner - took 966ms
ViewKey 3 is_owner - took 960ms
ViewKey 4 is_owner - took 974ms

`- 2.3%`

![image](https://user-images.githubusercontent.com/34972409/197878411-7449835e-dd6c-46aa-b7dc-5e39880cfb2a.png)